### PR TITLE
Update `macos` dependency to `catalina`

### DIFF
--- a/Formula/sudo-touchid.rb
+++ b/Formula/sudo-touchid.rb
@@ -9,7 +9,7 @@ class SudoTouchid < Formula
   # Restrict to macOS since TouchID is macOS-specific
   depends_on :macos
   # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
-  depends_on macos: :sierra
+  depends_on macos: :catalina
 
   def install
     # Ensure the script is executable and renamed


### PR DESCRIPTION
Homebrew has deprecated every macOS release before Catalina, so update the dependency to this. Catalina is also currently the oldest build artifact provided by the project.

This will need to be updated in 2026 when Catalina is deprecated: [ref](https://github.com/Homebrew/brew/blob/6b1d775bddd9190f5e67d7178c11e9890eec352b/Library/Homebrew/macos_version.rb#L31).

Resolves #7 