### PR TITLE
Fix deprecation when calling `depends_on :macos` with `depends_on macos:`

### DIFF
--- a/Formula/sudo-touchid.rb
+++ b/Formula/sudo-touchid.rb
@@ -6,11 +6,13 @@ class SudoTouchid < Formula
   license "EPL-2.0"
   head "https://github.com/artginzburg/sudo-touchid.git", branch: "main"
 
-  # Restrict to macOS since TouchID is macOS-specific
-  depends_on :macos
-  # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
-  depends_on macos: :catalina
-
+  on_macos do
+    # Restrict to macOS since TouchID is macOS-specific
+    depends_on :macos
+    # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
+    depends_on macos: :catalina
+  end
+  
   def install
     # Ensure the script is executable and renamed
     bin.install "sudo-touchid.sh" => "sudo-touchid"


### PR DESCRIPTION
Fix for Homebrew warning: "_Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead._"