### PR TITLE
fix: update sudo-touchid macOS dependency syntax

### DIFF
--- a/Formula/sudo-touchid.rb
+++ b/Formula/sudo-touchid.rb
@@ -7,9 +7,11 @@ class SudoTouchid < Formula
   head "https://github.com/artginzburg/sudo-touchid.git", branch: "main"
 
   # Restrict to macOS since TouchID is macOS-specific
-  depends_on :macos
-  # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
-  depends_on macos: :catalina
+  on_macos do
+    depends_on :macos
+    # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
+    depends_on macos: :catalina
+  end
 
   def install
     # Ensure the script is executable and renamed


### PR DESCRIPTION
This updates Formula/sudo-touchid.rb to use the current Homebrew style for macOS version constraints by nesting depends_on macos: :catalina inside an on_macos block.

This resolves the deprecation warning emitted by Homebrew when loading the formula.

Co-Authored-By: Oz <oz-agent@warp.dev>