### PR TITLE
Fix sudo-touchid macOS dependency DSL

### DIFF
--- a/Formula/sudo-touchid.rb
+++ b/Formula/sudo-touchid.rb
@@ -9,7 +9,9 @@ class SudoTouchid < Formula
   # Restrict to macOS since TouchID is macOS-specific
   depends_on :macos
   # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
-  depends_on macos: :catalina
+  on_macos do
+    depends_on macos: :catalina
+  end
 
   def install
     # Ensure the script is executable and renamed


### PR DESCRIPTION
## Summary
- move the minimum macOS dependency into an `on_macos` block to avoid the deprecated DSL warning

## Testing
- `brew audit --formula artginzburg/tap/sudo-touchid`
- `brew style artginzburg/tap/sudo-touchid`