### PR TITLE
sudo-touchid: wrap versioned macOS dependency in on_macos block

### DIFF
--- a/Formula/sudo-touchid.rb
+++ b/Formula/sudo-touchid.rb
@@ -6,10 +6,11 @@ class SudoTouchid < Formula
   license "EPL-2.0"
   head "https://github.com/artginzburg/sudo-touchid.git", branch: "main"
 
-  # Restrict to macOS since TouchID is macOS-specific
+  # Restrict to macOS (TouchID is macOS-specific); minimum: Catalina.
   depends_on :macos
-  # Optional: Specify minimum macOS version if known (e.g., 10.12.2 for TouchID)
-  depends_on macos: :catalina
+  on_macos do
+    depends_on macos: :catalina
+  end
 
   def install
     # Ensure the script is executable and renamed


### PR DESCRIPTION
## Summary

Silences the Homebrew deprecation warning emitted on every interaction with `sudo-touchid`:

> Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.
>   /opt/homebrew/Library/Taps/artginzburg/homebrew-tap/Formula/sudo-touchid.rb:12

## Change

Moves the versioned `depends_on macos: :catalina` into an `on_macos do ... end` block per current Homebrew style. The top-level `depends_on :macos` is kept so the formula remains macOS-only (otherwise the requirement would relax to "macOS >= 10.15 (or Linux)").

```ruby
# Restrict to macOS (TouchID is macOS-specific); minimum: Catalina.
depends_on :macos
on_macos do
  depends_on macos: :catalina
end
```

## Test plan

- [x] `brew style artginzburg/tap/sudo-touchid` — no offenses
- [x] `brew audit --tap=artginzburg/tap sudo-touchid` — exit 0
- [x] `brew info artginzburg/tap/sudo-touchid` — no deprecation warning; `Requirements: macOS, macOS >= 10.15 (or Linux)` (top-level `depends_on :macos` still enforces macOS-only)
- [x] Verified locally on macOS (Apple Silicon, `/opt/homebrew`)